### PR TITLE
ci: publish to test pypi if tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Build binary wheel and source tarball
         run: python -m build --sdist --wheel --outdir dist/
       - name: Publish to test PyPI
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startswith(github.ref, 'refs/tags'))
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__


### PR DESCRIPTION
This lets us bail early if there's something amiss w/ the publish before publishing to the real deal. This _should_ be unique because the tag should force setuptools-scm to bump the version.