### PR TITLE
chore: downgrade dask version requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ packages = find:
 python_requires = >=3.7
 install_requires =
     click ~= 8.0
-    dask ~= 2021.11
+    dask ~= 2021.08
     pandas ~= 1.3
     pyarrow ~= 6.0
     geopandas ~= 0.8.0


### PR DESCRIPTION
This is to align with the Planetary Computer's requirements.