### PR TITLE
Make pandas optional

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,8 +44,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install '.[dev,examples]'
 
-      - name: Test
+      - name: Test all except pandas
         run: pytest
+
+      - name: Install pandas
+        run: pip install '.[pandas]'
+
+      - name: Test only pandas
+        run: pytest -m pandas
 
       - name: Examples
         run: python examples/check_timesteps.py tests/data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Make pandas optional ([#43](https://github.com/gadomski/pyisd/pull/43))
+
 ## [0.3.0] - 2024-02-02
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 requires-python = ">=3.9"
-dependencies = ["click~=8.0", "pandas~=1.3"]
+dependencies = ["click~=8.0"]
 
 [project.scripts]
 isd = "isd.cli:main"
@@ -20,6 +20,12 @@ isd = "isd.cli:main"
 dev = ["mypy~=1.2", "pre-commit~=3.2", "pytest~=8.0", "ruff~=0.3.0"]
 examples = ["tqdm~=4.66"]
 docs = ["sphinx~=7.2"]
+pandas = ["pandas~=1.3"]
+
+[tool.pytest.ini_options]
+markers = [
+    "pandas: marks tests that require pandas",
+]
 
 [build-system]
 requires = ["setuptools>=45", "wheel"]

--- a/src/isd/batch.py
+++ b/src/isd/batch.py
@@ -4,12 +4,13 @@ import json
 from io import BytesIO
 from pathlib import Path
 from dataclasses import dataclass
-from typing import List, Union, Optional, Dict, Any, Iterator
+from typing import List, Union, Optional, Dict, Any, Iterator, TYPE_CHECKING
 import datetime
 
 from isd.record import Record
 
-import pandas
+if TYPE_CHECKING:
+    import pandas
 
 
 @dataclass
@@ -83,4 +84,13 @@ class Batch:
 
     def to_data_frame(self) -> pandas.DataFrame:
         """Reads a local ISD file into a DataFrame."""
+        try:
+            import pandas
+        except ImportError as e:
+            message = (
+                "The `pandas` optional dependency is required to use `to_data_frame`. "
+                "Install this dependency with `pip install 'isd[pandas]'`"
+            )
+            raise ImportError(message) from e
+
         return pandas.DataFrame([record.to_dict() for record in self.records])

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,6 +1,8 @@
 import datetime
 import json
 
+import pytest
+
 from isd import Batch
 
 
@@ -61,7 +63,10 @@ def test_batch_to_json(batch: Batch) -> None:
     assert first["datetime"] == "2021-01-01T00:15:00"
 
 
+@pytest.mark.pandas  # type: ignore
 def test_batch_to_df(batch: Batch) -> None:
+    pytest.importorskip("pandas")
+
     datetime_min = datetime.datetime(2021, 1, 5)
     df = batch.to_data_frame()
     df = df[df["datetime"] >= datetime_min]


### PR DESCRIPTION
Dear @gadomski ,

this PR makes pandas optional (still installable via `isd[io]`)